### PR TITLE
common/i386/predict-c.c: Don't use a list initializer in the declaration

### DIFF
--- a/common/i386/dct-c.c
+++ b/common/i386/dct-c.c
@@ -69,7 +69,7 @@ void x264_add16x16_idct_mmx( uint8_t *p_dst, int16_t dct[16][4][4] )
     x264_add8x8_idct_mmx( &p_dst[0],               &dct[0] );
     x264_add8x8_idct_mmx( &p_dst[8],               &dct[4] );
     x264_add8x8_idct_mmx( &p_dst[8*FDEC_STRIDE],   &dct[8] );
-    x264_add8x8_idct_mmx( &p_dst[8*FDEC_STRIDE+8], &dct[12] );                      idctµƒmmx≤ø∑÷
+    x264_add8x8_idct_mmx( &p_dst[8*FDEC_STRIDE+8], &dct[12] );                      idctùùmmxùùùù
 }
 */
 /***********************
@@ -115,10 +115,10 @@ extern void xavs_add16x16_idct8_sse2(uint8_t *dst, int16_t dct[4][8][8],int16_t 
 
 void xavs_add16x16_idct8_sse2( uint8_t *p_dst, int16_t dct[4][8][8],int16_t *tmp )
 {
-    xavs_add8x8_idct8_sse2( p_dst,                 dct[0] , tmp[0]);
-    xavs_add8x8_idct8_sse2( p_dst+8,               dct[1] , tmp[1]);
-    xavs_add8x8_idct8_sse2( p_dst+8*FDEC_STRIDE,   dct[2] , tmp[2]);
-    xavs_add8x8_idct8_sse2( p_dst+8*FDEC_STRIDE+8, dct[3] , tmp[3]);                 
+    xavs_add8x8_idct8_sse2( p_dst,                 dct[0] , &tmp[0]);
+    xavs_add8x8_idct8_sse2( p_dst+8,               dct[1] , &tmp[1]);
+    xavs_add8x8_idct8_sse2( p_dst+8*FDEC_STRIDE,   dct[2] , &tmp[2]);
+    xavs_add8x8_idct8_sse2( p_dst+8*FDEC_STRIDE+8, dct[3] , &tmp[3]);
 }
 
 //#else // ARCH_X86

--- a/common/i386/predict-c.c
+++ b/common/i386/predict-c.c
@@ -3,7 +3,7 @@
  *****************************************************************************
  * Copyright (C) 2009 xavs project
  *
- * Authors: 
+ * Authors:
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ extern void predict_8x8c_dc_left_mmxext( uint8_t *src,int i_neighbor );
 extern void predict_8x8c_dc_mmxext( uint8_t *src,int i_neighbor );
 extern void predict_8x8c_v_mmxext( uint8_t *src, int i_neighbor );
 extern void predict_8x8c_dc_top_mmxext( uint8_t *src,int i_neighbor );
-extern void predict_8x8c_p_core_mmxext( src, i00, b, c );
+extern void predict_8x8c_p_core_mmxext( uint8_t *src, int i00, int b, int c );
 extern void predict_8x8_h_mmxext( uint8_t *src, int i_neighbor );
 extern void predict_8x8_v_mmxext( uint8_t *src, int i_neighbor );
 extern void predict_8x8_dc_128_mmxext( uint8_t *src, int i_neighbor );


### PR DESCRIPTION
This will fix issues such as
```c
common/i386/predict-c.c:34:41: error: a parameter list without types is only allowed in a function definition

extern void predict_8x8c_p_core_mmxext( src, i00, b, c );

                                        ^

````